### PR TITLE
Refine children semantics and cover with test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ nimble.develop
 nimble.paths
 
 build
+
+.vscode

--- a/chroprof/api.nim
+++ b/chroprof/api.nim
@@ -11,16 +11,18 @@ proc getMetrics*(): MetricsTotals =
   ## current thread.
   result = profilerInstance.metrics
 
-proc enableProfiling*(callback: EventCallback = nil) =
+template enableProfiling*(callback: EventCallback) =
   ## Enables profiling for the the event loop running in the current thread.
   ## The client may optionally supply a callback to be notified of `Future`
   ## events.
   attachMonitoring(
-    if (isNil(callback)):
-      proc(e: Event) {.nimcall.} =
-        profilerInstance.processEvent(e)
-    else:
-      proc(e: Event) {.nimcall.} =
+      proc(e: Event) {.nimcall, gcsafe, raises: [].} =
         profilerInstance.processEvent(e)
         callback(e)
+  )
+
+template enableProfiling*() =
+  attachMonitoring(
+    proc(e: Event) {.nimcall, gcsafe, raises: [].} =
+      profilerInstance.processEvent(e)
   )

--- a/chroprof/config.nim
+++ b/chroprof/config.nim
@@ -1,0 +1,1 @@
+const chroprofDebug* {.booldefine.}: bool = false

--- a/chroprof/events.nim
+++ b/chroprof/events.nim
@@ -23,6 +23,11 @@ type
 
   EventCallback* = proc(e: Event) {.nimcall, gcsafe, raises: [].}
 
+const FinishStates* = [
+  ExtendedFutureState.Completed, ExtendedFutureState.Cancelled,
+  ExtendedFutureState.Failed,
+]
+
 var handleFutureEvent {.threadvar.}: EventCallback
 
 proc `location`*(self: Event): SrcLoc =

--- a/chroprof/utils.nim
+++ b/chroprof/utils.nim
@@ -1,0 +1,19 @@
+import std/options
+import chronos/srcloc
+
+proc push*(self: var seq[uint], value: uint): void =
+  self.add(value)
+
+proc pop*(self: var seq[uint]): uint =
+  let value = self[^1]
+  self.setLen(self.len - 1)
+  value
+
+proc peek*(self: var seq[uint]): Option[uint] =
+  if self.len == 0:
+    none(uint)
+  else:
+    self[^1].some
+
+proc `$`*(location: SrcLoc): string =
+  $location.procedure & "[" & $location.file & ":" & $location.line & "]"

--- a/tests/utils.nim
+++ b/tests/utils.nim
@@ -10,7 +10,7 @@ type SimpleEvent* = object
 #   global vars means we can't really do much better for now.
 var recording*: seq[SimpleEvent]
 var rawRecording*: seq[Event]
-var fakeTime*: Moment = Moment.now()
+var fakeTime*: Moment = Moment.init(0, 1.milliseconds)
 
 proc recordEvent(event: Event) {.nimcall, gcsafe, raises: [].} =
   {.cast(gcsafe).}:


### PR DESCRIPTION
This PR adds new tests for ensuring parent/child semantics is what we expect - including a test for children that complete after their parent, and nested children (which, incredibly, was missing).